### PR TITLE
fix windows specific bug for spawnsync and npm install

### DIFF
--- a/packages/azure-func/src/executors/publish/executor.spec.ts
+++ b/packages/azure-func/src/executors/publish/executor.spec.ts
@@ -133,7 +133,8 @@ describe('Publish Executor', () => {
 		npmProcessWill('fail');
 		await executor(options, context);
 		expect(childProcess.spawnSync).toHaveBeenCalledWith('npm', ['install', '--omit=dev'], {
-			cwd: '/root/some/path/dist/my-app',
+			cwd: expect.stringMatching(/dist(\\|\/)my-app/),
+			shell: true,
 			stdio: 'inherit',
 		});
 	});
@@ -168,7 +169,7 @@ describe('Publish Executor', () => {
 		funcProcessWill('succeed');
 		await executor(options, context);
 		expect(childProcess.spawnSync).toHaveBeenCalledWith('func', ['azure', 'functionapp', 'publish', 'some-azure-app'], {
-			cwd: '/root/some/path/dist/my-app',
+			cwd: expect.stringMatching(/dist(\\|\/)my-app/),
 			stdio: 'inherit',
 		});
 	});
@@ -180,7 +181,7 @@ describe('Publish Executor', () => {
 		delete options.azureAppName;
 		await executor(options, context);
 		expect(childProcess.spawnSync).toHaveBeenCalledWith('func', ['azure', 'functionapp', 'publish', 'my-app'], {
-			cwd: '/root/some/path/dist/my-app',
+			cwd: expect.stringMatching(/dist(\\|\/)my-app/),
 			stdio: 'inherit',
 		});
 	});

--- a/packages/azure-func/src/executors/publish/executor.ts
+++ b/packages/azure-func/src/executors/publish/executor.ts
@@ -44,6 +44,7 @@ function installDependenciesInDist(distDir: string): { success: boolean } {
 	return spawnSyncChecked('npm', ['install', '--omit=dev'], {
 		cwd: distDir,
 		stdio: 'inherit',
+		shell: true,
 	});
 }
 

--- a/packages/azure-func/src/executors/serve/executor.spec.ts
+++ b/packages/azure-func/src/executors/serve/executor.spec.ts
@@ -152,7 +152,7 @@ describe('Serve Executor', () => {
 		buildWill('fail', 'fail', 'succeed');
 		await expectNotResolving(executor(options, context));
 		expect(childProcess.spawn).toHaveBeenCalledWith('func', ['host', 'start', '--language-worker', '--', '--inspect=9229'], {
-			cwd: '/root/some/path/dist/my-app',
+			cwd: expect.stringMatching(/dist(\\|\/)my-app/),
 		});
 	});
 


### PR DESCRIPTION
Add shell:true option to spawnSync if calling batch files (npm)

[Related to limitation in windows for Spawn](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows) When spawning `.bat `and `.cmd` files. 

The scope of the change is limited to only add the option for spwaning npm, as func is not affected.