### PR TITLE
chore: fix peer dependencies in azure-func

### DIFF
--- a/packages/azure-func/CHANGELOG.md
+++ b/packages/azure-func/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.2] - 2026-03-13
+
+### Changed
+
+- Moved `typescript` and `vitest` from `peerDependencies` to `dependencies`.
+
 ## [5.0.1] - 2026-03-13
 
 ### Changed
@@ -181,7 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `serve` now watches the project for changes.
 
-[unreleased]: https://github.com/ziacik/nx-tools/compare/azure-func-5.0.1...HEAD
+[unreleased]: https://github.com/ziacik/nx-tools/compare/azure-func-5.0.2...HEAD
+[5.0.2]: https://github.com/ziacik/nx-tools/compare/azure-func-5.0.1...azure-func-5.0.2
 [5.0.1]: https://github.com/ziacik/nx-tools/compare/azure-func-5.0.0...azure-func-5.0.1
 [5.0.0]: https://github.com/ziacik/nx-tools/compare/azure-func-4.0.0...azure-func-5.0.0
 [4.0.0]: https://github.com/ziacik/nx-tools/compare/azure-func-3.3.1...azure-func-4.0.0

--- a/packages/azure-func/package.json
+++ b/packages/azure-func/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "@ziacik/azure-func",
-	"version": "5.0.1",
+	"version": "5.0.2",
 	"dependencies": {
 		"@nx/devkit": "^22.0.0",
-		"@swc/helpers": "~0.5.18"
+		"@swc/helpers": "~0.5.18",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.0"
 	},
 	"peerDependencies": {
 		"@nx/js": "^22.0.0",
 		"@nx/node": "^22.0.0",
-		"@nx/vite": "^22.0.0",
-		"typescript": "~5.9.3",
-		"vitest": "^4.0.0"
+		"@nx/vite": "^22.0.0"
 	},
 	"type": "commonjs",
 	"main": "./src/index.js",


### PR DESCRIPTION
Moves TypeScript and Vitest from peerDependencies to dependencies to ensure required tooling is installed for consumers and avoid missing peer warnings.